### PR TITLE
fix: remove global style in renderer

### DIFF
--- a/packages/nuxt/src/runtime/renderer.vue
+++ b/packages/nuxt/src/runtime/renderer.vue
@@ -94,7 +94,7 @@ onMounted(() => {
       v-bind="props"
     />
   </template>
-  <Teleport to="body">
+  <Teleport to="#__compodium-root">
     <div
       v-if="showGrid"
       class="grid-background absolute z-50 inset-0"
@@ -111,11 +111,3 @@ onMounted(() => {
     />
   </Teleport>
 </template>
-
-<style>
-body {
-  position: relative;
-  width: fit-content;
-  height: fit-content;
-}
-</style>

--- a/packages/nuxt/src/runtime/root.vue
+++ b/packages/nuxt/src/runtime/root.vue
@@ -17,9 +17,19 @@ const PreviewComponent = url?.startsWith('/__compodium__/renderer') && defineAsy
 
 <template>
   <Suspense v-if="url?.startsWith('/__compodium__/renderer')">
-    <PreviewComponent>
-      <RendererComponent />
-    </PreviewComponent>
+    <div id="__compodium-root">
+      <PreviewComponent>
+        <RendererComponent />
+      </PreviewComponent>
+    </div>
   </Suspense>
   <NuxtRoot v-else />
 </template>
+
+<style scoped>
+#__compodium-root {
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+}
+</style>

--- a/packages/nuxt/test/basic.test.ts
+++ b/packages/nuxt/test/basic.test.ts
@@ -21,7 +21,7 @@ describe('basic', async () => {
   describe('renderer', () => {
     it('is mounted in development', async () => {
       const html = await $fetch('/__compodium__/renderer')
-      expect(html).toContain('<div id="compodium-default-preview">')
+      expect(html).toContain('<div id="compodium-default-preview"')
     })
   })
 

--- a/packages/nuxt/test/custom-compodium-dir.test.ts
+++ b/packages/nuxt/test/custom-compodium-dir.test.ts
@@ -17,7 +17,8 @@ describe('custom compodium dir', async () => {
   describe('renderer', () => {
     it('is mounted inside custom preview', async () => {
       const html = await $fetch('/__compodium__/renderer')
-      expect(html).toContain('<div id="custom-preview">')
+      console.log(html)
+      expect(html).toContain('<div id="custom-preview"')
     })
   })
 

--- a/packages/nuxt/test/custom-compodium-dir.test.ts
+++ b/packages/nuxt/test/custom-compodium-dir.test.ts
@@ -17,7 +17,6 @@ describe('custom compodium dir', async () => {
   describe('renderer', () => {
     it('is mounted inside custom preview', async () => {
       const html = await $fetch('/__compodium__/renderer')
-      console.log(html)
       expect(html).toContain('<div id="custom-preview"')
     })
   })


### PR DESCRIPTION
Replaces global styles in the renderer by scoped styles in the root component to avoid leaking into the user's app.

Resolves #22 