### PR TITLE
fix(meta): handle unresolved imports in getComponentMeta function

### DIFF
--- a/packages/core/src/plugins/meta/checker.ts
+++ b/packages/core/src/plugins/meta/checker.ts
@@ -23,7 +23,10 @@ export function createChecker(dirs: ComponentsDir[], rootDir = process.cwd(), ts
 
   const checker = {
     ...metaChecker,
-    getComponentMeta: (componentPath: string): CompodiumMeta => {
+    getComponentMeta: (componentPath: string): CompodiumMeta | undefined => {
+      // A component that is not on disk becomes an unresolved import inside the virtual meta entry
+      if (!existsSync(componentPath)) return undefined
+
       const meta = getComponentMeta(metaChecker, componentPath)
       return {
         props: meta.props

--- a/packages/vue/test/meta.spec.ts
+++ b/packages/vue/test/meta.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { fileURLToPath } from 'node:url'
+import { joinURL } from 'ufo'
+import { dirname } from 'pathe'
+
+import { createViteServer } from './utils'
+
+const componentPath = (name: string) => fileURLToPath(joinURL(dirname(import.meta.url), './fixtures/basic/src/components', name))
+
+describe('meta api', async () => {
+  const server = await createViteServer('./fixtures/basic')
+
+  it('describes a component it can resolve', async () => {
+    const resp = await server.get('/__compodium__/api/meta').query({ component: componentPath('BasicComponent.vue') })
+
+    expect(resp.status).toBe(200)
+    expect(resp.body.props.map((prop: { name: string }) => prop.name)).toContain('foo')
+  }, 30_000)
+
+  it('answers 404 for a component that does not exist', async () => {
+    const resp = await server.get('/__compodium__/api/meta').query({ component: componentPath('MissingComponent.vue') })
+
+    expect(resp.status).toBe(404)
+  })
+
+  it('answers 400 when no component is named', async () => {
+    const resp = await server.get('/__compodium__/api/meta')
+
+    expect(resp.status).toBe(400)
+  })
+})


### PR DESCRIPTION
Discussed privately on Discord

The `!meta` branch in the meta middleware could never fire — `getComponentMeta` is typed `CompodiumMeta` and always returns an object literal, so a missing component came back 200 with empty props instead of 404, indistinguishable from a component that genuinely has none.

Now guards on the file existing and returns `undefined`, which makes the existing 404 branch work as intended. Added a small spec for the 200 / 404 / 400 cases.